### PR TITLE
Startup enhancements to avoid loosing ncm-cdispd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,8 @@
 	    <postinstallScriptlet>
 	      <script>
 	        /sbin/chkconfig --add ${project.artifactId}
+                # Ensure that profile has been updated to the last format, if any change, to prevent potential ncm-cdispd crash at restart
+                ccm-fetch --force
 	        /sbin/service ${project.artifactId} restart
 	      </script>
 	    </postinstallScriptlet>

--- a/src/main/daemon/ncm-cdispd
+++ b/src/main/daemon/ncm-cdispd
@@ -17,7 +17,9 @@ start() {
     bash -c "echo -n 'Starting $prog:'"
     daemon "$DISPATCH" -D
     RETVAL=$?
-    [ "$RETVAL" = 0 ] && touch /var/lock/quattor/ncm-cdispd
+    # Mark the attempt to start the daemon, even if not successful.
+    # This will allow the monitoring cron job to attempt to restart it
+    touch /var/lock/quattor/ncm-cdispd
     echo
 }
 

--- a/src/main/scripts/check-ncm-cdispd
+++ b/src/main/scripts/check-ncm-cdispd
@@ -9,6 +9,8 @@ status=$?
 if [ $status -eq 2 -o $status -eq 1 ]         # Daemon is dead
 then
   echo "Restarting $daemon..."
+  # First ensure that we have a good profile in the expected format in case of a problem before
+  ccm-fetch --force
   ${service} $daemon start
 elif [ $status -eq 3 ]
 then


### PR DESCRIPTION
...the profile

(in startup script and in monitoring cron job)
- Create daemon lock file whatever is the startup status to ensure that the cron job
  will restart it in case of a failure during installation.
