### PR TITLE
Improve ncd status logging

### DIFF
--- a/src/main/scripts/ncm-cdispd
+++ b/src/main/scripts/ncm-cdispd
@@ -663,6 +663,7 @@ sub log_failed_components {
             my $fh = CAF::FileEditor->new("$comp_state_dir/$component");
             my $comp_msg = "$fh";
             chomp $comp_msg;
+            $comp_msg = "(no message)" unless $comp_msg;
             $this_app->warn("Component $component failed with message: $comp_msg");
             $fh->close();
         }


### PR DESCRIPTION
Fixes #12.

In addition, restore the original formatting of ncd status line in `/var/log/ncm-cdispd` to avoid breaking existing parser for this file (I know that line is parsed to raise attention when a component failed).

Still work in progress, would like to add the list of failed components as described in #12.
