### PR TITLE
Fix location check-ncm-cdispd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
                 <directoryIncluded>false</directoryIncluded>
                 <sources>
                   <source>
-                    <location>${project.build.directory}/quattor</location>
+                    <location>${project.build.directory}/quattor/scripts</location>
                     <includes>
                       <include>**/*</include>
                     </includes>


### PR DESCRIPTION
Without this patch, the check is installed in `/usr/quattor/scripts/scripts/check-ncm-cdispd` instead of `/usr/quattor/scripts/check-ncm-cdispd`
