### PR TITLE
bump build-tools version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.35</version>
+    <version>1.39</version>
   </parent>
   <scm>
     <connection>scm:git:git://github.com/quattor/ncm-cdispd.git</connection>


### PR DESCRIPTION
Fixes #10

To be redone/updated when new `mavne-tools` 1.39 is out
