### PR TITLE
Add RPM dependency on crontabs and logrotate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
             <name>${project.artifactId}</name>
             <needarch>noarch</needarch>
             <url>https://github.com/quattor/ncm-cdispd/tree/master</url>
+            <requires>
+              <require>crontabs</require>
+              <require>logrotate</require>
+            </requires>
             <mappings>
               <mapping>
                 <directory>/usr/lib/perl</directory>


### PR DESCRIPTION
We ship cron jobs and logrotate configuration and should therefore depend on `crontabs` and `logrotate` to comply with packaging guidelines.