### PR TITLE
Add chkconfig as a rpm dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
             <requires>
               <require>crontabs</require>
               <require>logrotate</require>
+              <require>chkconfig</require>
             </requires>
             <mappings>
               <mapping>


### PR DESCRIPTION
Fixes #59 
 Add chkconfig as an rpm dependency of  ncm-cdispd to prevent incorrect creation of the /etc/init.d directory in OSes where chkconfig is not part of the base install e.g. EL9 variants.