### PR TITLE
Remove double test counting

### DIFF
--- a/src/test/perl/compare_profiles.t
+++ b/src/test/perl/compare_profiles.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 12;
+use Test::More;
 use Test::NoWarnings;
 use Test::Quattor qw(profile1 profile2);
 use CDISPD::Utils;
@@ -67,3 +67,4 @@ for (my $i=0; $i<$iclist_length; $i++) {
 
 Test::NoWarnings::had_no_warnings();
 
+done_testing();

--- a/src/test/perl/is_active.t
+++ b/src/test/perl/is_active.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Test::More;
 use Test::NoWarnings;
 use Test::Quattor qw(profile1 broken_profile);
 use CDISPD::Utils;
@@ -42,3 +42,4 @@ ok(!CDISPD::Utils::is_active($comp_config,$component), "Configuration module $co
 
 Test::NoWarnings::had_no_warnings();
 
+done_testing();


### PR DESCRIPTION
Split out from #61.

* had_no_warnings caused double test in older versions

Probably requires newer versions of `Test::More` and `Test::NoWarnings` than are shipped in EL8.